### PR TITLE
periodically delete old chunks from chunk_map to prevent memory leak

### DIFF
--- a/lib/gelfd2/chunked_parser.rb
+++ b/lib/gelfd2/chunked_parser.rb
@@ -1,12 +1,19 @@
 module Gelfd2
   class ChunkedParser
-    @@chunk_map = Hash.new {|hash,key| hash[key] = {:total_chunks => 0, :chunks => {} } }
+    @@chunk_map = Hash.new {|hash,key| hash[key] = {:total_chunks => 0, :last_chunk_time => 0, :chunks => {} } }
+    @@msg_timeout = 20
+    @@msg_counter = 0
 
     attr_accessor :message_id, :max_chunks, :decoded_data, :chunks, :seen
 
     def self.parse(data)
       msg_id = self.parse_chunk(data)
       if @@chunk_map[msg_id][:chunks].size == @@chunk_map[msg_id][:total_chunks]
+        @@msg_counter = @@msg_counter+1
+        if @@msg_counter == 1000
+          @@msg_counter = 0
+          self.delete_old_chunks()
+        end 
         assemble_chunks(msg_id)
       end
     end
@@ -40,7 +47,21 @@ module Gelfd2
         raise TooManyChunksError, "#{total_number} greater than #{MAX_CHUNKS}" if total_number > MAX_CHUNKS
         @@chunk_map[msg_id][:total_chunks] = total_number.to_i
         @@chunk_map[msg_id][:chunks].merge!({seq_number.to_i => zlib_chunk})
+        @@chunk_map[msg_id][:last_chunk_time] = Time.now.getutc.to_i
         msg_id
+      end
+    end
+
+    private
+    def self.delete_old_chunks()
+      time = Time.now.getutc.to_i
+      begin
+        @@chunk_map.each do |msg_id, msg|
+          if msg[:last_chunk_time]+@@msg_timeout > time
+            next
+          end
+          @@chunk_map.delete(msg_id)
+        end
       end
     end
 


### PR DESCRIPTION
Hello. We encountered a memory leak in fluentd which I described here https://github.com/MerlinDMC/fluent-plugin-input-gelf/issues/5 First I thought that the culprit was fluent-plugin-input-gelf
 plugin, but it seems that the root cause is in gelfd2 gem. So basically when a chunk from chunked message is lost, all other chunks stay in chunk_map forever because assemble_chunks() is never called and that leads to a memory leak. I added a feature to delete messages with newest chunk older than 20s each 1000 messages. Sometimes we observed 2gb leak over few hours during the busiest time of the day and this patch fixed it.

I never used ruby before so this may look like a dirty hack but I think there should be some mechanism to get rid of old chunks especially since gelf messages may be sent via udp.