### PR TITLE
Close GzipReader after reading to do CRC checks

### DIFF
--- a/lib/gelfd2/gzip_parser.rb
+++ b/lib/gelfd2/gzip_parser.rb
@@ -5,7 +5,9 @@ module Gelfd2
     def self.parse(data)
       begin
         t = Zlib::GzipReader.new(StringIO.new(data))
-        t.read
+        decompressed = t.read
+        t.close  # may trigger CRCError if there was corruption
+        decompressed
       #raise NotYetImplementedError, "GZip decoding is not yet implemented"
       rescue Exception => e
         raise DecodeError, "Failed to decode data: #{e}"


### PR DESCRIPTION
Without closing, you won't get any CRC checks: this may result in
invalid data being propagated. See:
https://github.com/MerlinDMC/fluent-plugin-input-gelf/pull/16

The difference between:

    $ echo 'Your argument is sound, nothing but sound.' |
      python3 -c 'import gzip,sys;b=gzip.compress(sys.stdin.buffer.read());sys.stdout.buffer.write(b[0:20]+b[32:])' |
      ruby -e 'require "zlib";r=Zlib::GzipReader.new(STDIN);print(r.read)'
    Your argul, nothing but argul.

And:

    $ echo 'Your argument is sound, nothing but sound.' |
      python3 -c 'import gzip,sys;b=gzip.compress(sys.stdin.buffer.read());sys.stdout.buffer.write(b[0:20]+b[32:])' |
      ruby -e 'require "zlib";r=Zlib::GzipReader.new(STDIN);print(r.read);r.close'
    Your argul, nothing but argul.
    Traceback (most recent call last):
        1: from -e:1:in `<main>'
    -e:1:in `close': invalid compressed data -- crc error (Zlib::GzipFile::CRCError)